### PR TITLE
scrape dc police rosters for #62

### DIFF
--- a/preprocess/clean/DC/src/dl-roster.py
+++ b/preprocess/clean/DC/src/dl-roster.py
@@ -1,0 +1,19 @@
+import requests
+import pandas as pd
+
+
+def fetch_employee_roster():
+    roster_url = 'https://datagate.dc.gov/ess/v1.0/employees'
+    response = requests.get(
+        roster_url,
+        headers={"Origin": "https://dchr.dc.gov"}
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+if __name__ == '__main__':
+    employee_roster = fetch_employee_roster()
+    assert employee_roster['success']
+    out = pd.DataFrame(employee_roster['data'])
+    out.to_csv('output/dc-employee-roster-raw.csv', index=False)


### PR DESCRIPTION
We don't FOIA/PRA for records for DC, instead we download them from https://dchr.dc.gov/publicbodyinfo#gsc.tab=0 (see #62). This PR will download and format the data for our schema. Ideally we'd then be able to schedule it to run on a regular basis to get updated snapshots.

So far we just have code to download the full roster from the website, still need to clean fields and standardize the column names.